### PR TITLE
MFW-801: system_manager: Add zzz-reload-system

### DIFF
--- a/sync/openwrt/operations.py
+++ b/sync/openwrt/operations.py
@@ -14,4 +14,4 @@ sync.registrar.register_operation("restart-dhcp", [""], ["/etc/init.d/dnsmasq re
 
 sync.registrar.register_operation("restart-cron", [""], ["/etc/init.d/cron stop ; /etc/init.d/cron enable ; /etc/init.d/cron start "], 35, None)
 
-sync.registrar.register_operation("startup-scripts", [""], ["/etc/init.d/startup boot ; /etc/init.d/system restart"], 40, None)
+sync.registrar.register_operation("startup-scripts", [""], ["/etc/init.d/startup boot"], 40, None)


### PR DESCRIPTION
In the case when we are booting up with default settings, changes
made to /etc/config/system are not being set properly.  This is
because /etc/init.d/system runs before /etc/init.d/sync-settings.

When system_manager writes out startup scripts, also write out
zzz-reload-system, which includes a call to
/etc/init.d/system reload.  This will restart system if any changes
were made to /etc/config/system.  With zzz-reload-system, we don't
need to call /etc/init.d/system restart explicitly in operations.

MFW-801