### PR TITLE
MFW-844-843-842: system_manager: Deal with timezone's with / in them

### DIFF
--- a/sync/openwrt/system_manager.py
+++ b/sync/openwrt/system_manager.py
@@ -201,7 +201,7 @@ class SystemManager:
         file.write("\n\n")
 
         file.write('TMPFILE="/tmp/system"\n')
-        file.write(r'''/bin/sed -e "s/option timezone .*/option timezone '%s'/" /etc/config/system > $TMPFILE''' % time_zone)
+        file.write(r'''/bin/sed -e "s@option timezone .*@option timezone '%s'@" /etc/config/system > $TMPFILE''' % time_zone)
         file.write('\n\n')
 
         file.write('if ! diff /etc/config/system $TMPFILE >/dev/null 2>&1 ; then cp $TMPFILE /etc/config/system ; fi\n')


### PR DESCRIPTION
Use @ in sed script so it doesn't get confused by the / that may
be in the timezone definition.

MFW-844
MFW-843
MFW-842