### PR TITLE
MFW-847: network_manager: openvpn: Suppress persist-tun in client configs

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -398,7 +398,10 @@ class NetworkManager:
         file = open(filename, "wb+")
         # only base64 is currently supported
         if conffile.get('encoding') == 'base64':
-            file.write(base64.b64decode(conffile.get('contents')).replace(b'nobind',b'#nobind'))
+            contents = base64.b64decode(conffile.get('contents'))
+            contents = contents.replace(b'nobind',b'#nobind')
+            contents = contents.replace(b'persist-tun',b'#persist-tun')
+            file.write(contents)
             file.flush()
             file.close()
             print("%s: Wrote %s" % (self.__class__.__name__, filename))


### PR DESCRIPTION
If an openvpn configuration file specifies 'persist-tun', remove it
before writing the file out.  That way, if the vpn connection goes
down, the tun interface is removed.  That enables us to correctly
reflect the status of the connection on the UI and in our wan routing
logic

MFW-847