### PR TITLE
MFW-797: network_manager: Do ifdown/ifup on openvpn interface name

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -802,7 +802,7 @@ class NetworkManager(Manager):
 
             # register a new operation to restart this interface if this config file changes
             # register the config file with the new operation
-            cmd = "ifdown " + intf["device"] + " ; " + "ifup " + intf["device"]
+            cmd = "ifdown " + intf["name"] + " ; " + "ifup " + intf["name"]
             opname = "restart-" + intf["device"]
             registrar.register_operation(opname, [""], [cmd], 99, None)
             registrar.register_file(path, opname, self)


### PR DESCRIPTION
openwrt's ifdown/ifup commands operate on interfaces name (ie.
dogfood, expressvpn, etc) not device name (ie tun0).

MFW-797