### PR TITLE
Fix ip6addr for static address and alias configs

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -556,8 +556,7 @@ class NetworkManager(Manager):
         elif intf.get('v6ConfigType') == "STATIC":
             if intf.get('v6StaticAddress') is not None and intf.get('v6StaticPrefix') is not None:
                 file.write("\toption proto 'static'\n")
-                file.write("\toption ip6addr '%s'\n" % intf.get('v6StaticAddress'))
-                file.write("\toption ip6prefix '%s'\n" % intf.get('v6StaticPrefix'))
+                file.write("\toption ip6addr '%s/%s'\n" % (intf.get('v6StaticAddress'), intf.get('v6StaticPrefix')))
                 if intf.get('wan') and intf.get('v6StaticGateway') is not None:
                     file.write("\toption ip6gw '%s'\n" % intf.get('v6StaticGateway'))
 
@@ -577,8 +576,7 @@ class NetworkManager(Manager):
         file.write("config interface '%s'\n" % (intf['logical_name']+"6"+"_"+str(count)))
         file.write("\toption ifname '%s'\n" % intf['ifname'])
         file.write("\toption proto 'static'\n")
-        file.write("\toption ip6addr '%s'\n" % alias.get('v6Address'))
-        file.write("\toption ip6prefix '%s'\n" % alias.get('v6Prefix'))
+        file.write("\toption ip6addr '%s/%s'\n" % (alias.get('v6Address'), alias.get('v6Prefix')))
 
     def create_settings_devices(self, settings, prefix, delete_list):
         """create device settings"""


### PR DESCRIPTION
To test this fix, start with a MFW device/environment that does not have this fix. If you configure a static IPv6 address for one of the interfaces, and then look at the interface status at the command line (ifconfig), you'll see the address you configure does NOT get assigned to the interface. It is effectively ignored.

With this fix applied, static IPv6 addresses will be assigned to devices as expected.

Here are the detailed fix/commit notes:

I use static IPv6 networks/addresses in my development environment
and it seems we're doing the wrong thing in sync-settings with
the ip6addr and ip6prefix fields in /etc/config/network

According to the OpenWRT docs:

ip6addr = Assign given IPv6 address to this interface (CIDR notation)
ip6prefix = IPv6 prefix routed here for use on other interfaces

I modified network_manager.py to combine the configured IPv6 address
and prefix when adding the ip6addr field, and removed the ip6prefix.
Without this fix, the static IPv6 address I configure on an interface
is ignored. When I manually modify /etc/config/network with this
fixed configuration, it works as expected.
