### PR TITLE
wireless_manager: Handle undefined wirelessVisibility

### DIFF
--- a/sync/debian/wireless_manager.py
+++ b/sync/debian/wireless_manager.py
@@ -277,7 +277,10 @@ class WirelessManager(Manager):
                 self.hostapdConfFile.write("country_code=US\n")
                 self.hostapdConfFile.write("max_num_sta=255\n")
                 self.hostapdConfFile.write("auth_algs=1\n")
-                self.hostapdConfFile.write("ignore_broadcast_ssid=%u\n" % intf.get('wirelessVisibility'))
+                if intf.get('wirelessVisibility') != None:
+                    self.hostapdConfFile.write("ignore_broadcast_ssid=%u\n" % intf.get('wirelessVisibility'))
+                else:
+                    self.hostapdConfFile.write("ignore_broadcast_ssid=0\n")
 
                 channel = intf.get('wirelessChannel')
 


### PR DESCRIPTION
On upgrade to 15.1 we run sync-settings as part of the sync-settings
package postinst.  Customers with wireless interfaces that have not
made a network settings change post-14.2 will not have the
wirelessVisibility field defined in their network.js, which means
that the postinst sync-settings call will fail, which can cause
the upgrade to 15.1 to stall.  If wirelessVisibility isn't defined
for a wireless interface, just write out a 0.

NGFW-13205