### PR TITLE
Fix interface validation for PPPoE configuration

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -765,7 +765,7 @@ class NetworkManager(Manager):
         if '-' in intf.get("name"):
             raise Exception("Invalid interface name contains hyphen: " + intf.get('name'))
 
-        if intf.get("v4ConfigType") not in [None, "STATIC", "DHCP", "DISABLED"]:
+        if intf.get("v4ConfigType") not in [None, "STATIC", "DHCP", "PPPOE", "DISABLED"]:
             raise Exception("Invalid v4ConfigType: " + intf.get('name') + " " + intf.get("v4ConfigType"))
 
         if intf.get("v4Aliases") is not None:


### PR DESCRIPTION
The validate_interface function in network_manager for MFW was throwing an exception for PPPoE interfaces. I looks like PPPOE simply wasn't included in the list of valid interface types. Adding to the array resolves the exception and allows settings to be saved normally.