### PR TITLE
Mfw 1040 routing fixes

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -577,11 +577,9 @@ class NetworkManager(Manager):
                 if len(dnslist) == 0:
                     raise Exception('Use Peer DNS is disabled and no DNS servers are configured')
                 file.write("\toption dns '%s'\n" % dnslist)
-            # FIXME
-            # If its PPPoE the "netfilterDev" is the actual device that netfilter rules should match on
-            # In this case we need to set 'netfilterDev' to 'pppX' so subsequent modules know the proper
-            # netfilter device to use
-            # intf['netfilterDev'] = ppp0
+
+            # PPPOE interfaces need to set netfilterDev to the PPPOE tunnel
+            intf['netfilterDev'] = "pppoe-" + intf['logical_name'] + "4"
 
         elif intf.get('v4ConfigType') == "DISABLED":
             # This needs to be written for addressless bridges


### PR DESCRIPTION
This fixes the wan routing rules for PPPOE connections, but I have a couple questions:

This logic replaces the interface name for a PPPOE interface in the nat-sys and interface-marks NFT tables from the logical interface to the PPPOE tunnel interface. Do we need to do something with the logical interface still? (I noticed some IPv6 ICMPv6 packets failing after making the change, but may not have been something serious).  Is there value in marking both the PPPOE tunnel as an interface and also the logical interface, or would this just be destroying the mark for the PPPOE tunnel traffic?

@jccoffin and I noticed the main routing table still gets populated with the PPPOE tunnel route (The wan.X table also gets the route from the ip4table configuration, which is what we actually use for the routing), but is there something we need to do with the main routing entry also? I don't see any issues yet with it, but curious if we can think of a reason to get rid of it form the main table.