### PR TITLE
route_manager: Check ipv6Enabled for 'up' tests

### DIFF
--- a/sync/openwrt/route_manager.py
+++ b/sync/openwrt/route_manager.py
@@ -299,7 +299,7 @@ class RouteManager(Manager):
 
                         if down_by_attribute is False:
                             file.write("up policy-%d %d %s &\n" % (policyId, interfaceId, interfaceName))
-                            if interfaceName != interface6Name:
+                            if intf.get('ipv6Enabled') and interfaceName != interface6Name:
                                 file.write("up policy-%d %d %s &\n" % (policyId, interfaceId, interface6Name))
 
                             for criterion in criteria:


### PR DESCRIPTION
Check for ipv6Enabled before writing out 'up' tests
for wans.  Without this check, we might write bogus
interfaces names that cause wan manager to think that
the ipv4 interface is down.

MFW-1051