### PR TITLE
network_manager: Sync vlan device with vlan name

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -58,6 +58,10 @@ class NetworkManager(Manager):
             if intf.get('openvpnBoundInterfaceId'):
                 intf['boundInterfaceId'] = intf.pop('openvpnBoundInterfaceId', "0")
 
+            # sync vlan device with vlan name for debuggability's sake
+            if intf.get('type') == 'VLAN':
+                intf['device'] = intf.get('name')
+
         # Give any OpenVPN interfaces tun devices
         openvpn_set_tun_interfaces(settings_file.settings)
 


### PR DESCRIPTION
For the sake of debuggability, sync the VLAN interface name with
the device name

MFW-1146