### PR TITLE
network_manager: Fix overlapping vlan validation

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -1073,7 +1073,7 @@ class NetworkManager(Manager):
         if intf.get("type") == 'VLAN':
                 interfaces = settings_file.settings.get('network').get('interfaces')
                 for interface in interfaces:
-                    if interface.get('enabled') and interface.get('type') == 'VLAN' and interface.get('vlanid') == intf.get('vlanid') and interface.get('boundInterfaceId') == intf.get('boundInterfaceId'):
+                    if interface.get('interfaceId') != intf.get('interfaceId') and interface.get('enabled') and interface.get('type') == 'VLAN' and interface.get('vlanid') == intf.get('vlanid') and interface.get('boundInterfaceId') == intf.get('boundInterfaceId'):
                         vlanBoundInterface = network_util.get_interface_by_id(settings_file.settings, intf.get('boundInterfaceId'))
                         raise Exception("Invalid VLAN config: A VLAN with parent interface " + vlanBoundInterface.get('name') + " and vlanId " + str(intf.get('vlanid')) + " already exists")
 


### PR DESCRIPTION
We need to check that the interfaceIds of the interfaces we are
comparing are different, otherwise we are comparing the interface
to itself

MFW-1168