### PR TITLE
network_manager: Use 'any' if simApn is None

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -285,6 +285,8 @@ class NetworkManager(Manager):
 
         if intf.get('simApn') is not None:
             file.write("\toption apn '%s'\n" % intf.get('simApn'))
+        else:
+            file.write("\toption apn 'any'\n")
 
         if intf.get('simProfile') is not None:
             file.write("\toption profile '%d'\n" % intf.get('simProfile'))


### PR DESCRIPTION
This is the value suggested by openwrt documentation for
a "no-settings" connection

MFW-1032