### PR TITLE
network_manager: Add route-nopull to openvpn configs

### DIFF
--- a/sync/openwrt/network_manager.py
+++ b/sync/openwrt/network_manager.py
@@ -494,6 +494,7 @@ class NetworkManager(Manager):
             contents = contents.replace(b'nobind',b'#nobind')
             contents = contents.replace(b'persist-tun',b'#persist-tun')
             file.write(contents)
+            file.write(b'route-nopull\n')
             file.flush()
             file.close()
             print("%s: Wrote %s" % (self.__class__.__name__, filename))


### PR DESCRIPTION
Routing is to be decided by the devices WAN routing rules, so add
'route-nopull' to prevent routes being pushed by the server.

MFW-1120