### PR TITLE
interface_manager: Add mss clamping for wg

### DIFF
--- a/sync/openwrt/interface_manager.py
+++ b/sync/openwrt/interface_manager.py
@@ -142,9 +142,9 @@ add rule inet interface-marks postrouting-interface-marks ct state new jump mark
             file.write("add rule inet interface-marks mark-dst-interface ct direction original oifname %s ct mark set ct mark and 0x%x or 0x%x\n" %
                        (interface_name, self.SERVER_TYPE_MASK_INVERSE, (interface_type << self.SERVER_TYPE_SHIFT) & self.SERVER_TYPE_MASK))
 
-            if intf.get('v4ConfigType') == "PPPOE":
+            if intf.get('v4ConfigType') == "PPPOE" or intf.get('type') == "WIREGUARD":
                 file.write("\n")
-                file.write("# For PPPoE interfaces, set the MSS size to route mtu in the mark-dst-interface chain\n")
+                file.write("# For PPPoE and wireguard interfaces, set the MSS size to route mtu in the mark-dst-interface chain\n")
                 file.write("add rule inet interface-marks mark-dst-interface mark & 0x0000ff00 == 0x%x tcp flags syn tcp option maxseg size set rt mtu\n" % (interface_id << self.DST_INTERFACE_SHIFT))
                 file.write("\n")
 


### PR DESCRIPTION
Wireguard performance is very sensitive to mtu issues, so do
mss clamping on traffic exiting wireguard interfaces just like
we do for pppoe interfaces

MFW-1244